### PR TITLE
Build lein from GitHub

### DIFF
--- a/diaconis/clojure/default.nix
+++ b/diaconis/clojure/default.nix
@@ -1,49 +1,52 @@
 with import <nixpkgs> {};
 let
-  tesser = stdenv.mkDerivation {
-    name = "tesser";
+  buildLeinFromGitHub = { name, owner, repo, rev, sha256, cd}:
+  stdenv.mkDerivation {
+    name = name;
     src = fetchFromGitHub {
-      owner = "aphyr";
-      repo = "tesser";
-      rev = "b7b67dfaf25f1764c70c90dc6681dd333d24d6a4";
-      sha256 = "1vma6ram4qs7llnfn84d4xvpn0q7kmzmkmsjpnkpqnryff9w2gvr";
+      owner = owner;
+      repo = repo;
+      rev = rev;
+      sha256 = sha256;
     };
-    buildInputs = [ leiningen ];
-    buildPhase = ''
-      # https://blog.jeaye.com/2017/07/30/nixos-revisited/
-      # For leiningen
-      export HOME=$PWD
-      export LEIN_HOME=$HOME/.lein
-      mkdir -p $LEIN_HOME
-      echo "{:user {:local-repo \"$LEIN_HOME\"}}" > $LEIN_HOME/profiles.clj
-      cd core
-      LEIN_SNAPSHOTS_IN_RELEASE=1 ${leiningen}/bin/lein uberjar
-    '';
-    installPhase = ''
-      cp target/tesser.core-*-standalone.jar $out
-    '';
+      buildInputs = [ leiningen ];
+      buildPhase = ''
+        # https://blog.jeaye.com/2017/07/30/nixos-revisited/
+        # For leiningen
+        export HOME=$PWD
+        export LEIN_HOME=$HOME/.lein
+        mkdir -p $LEIN_HOME
+        echo "{:user {:local-repo \"$LEIN_HOME\"}}" > $LEIN_HOME/profiles.clj
+        cd ${cd}
+        LEIN_SNAPSHOTS_IN_RELEASE=1 ${leiningen}/bin/lein uberjar
+      '';
+      installPhase = ''
+        cp target/${repo}*-standalone.jar $out
+      '';
   };
-  matrix = stdenv.mkDerivation {
+  tesser = buildLeinFromGitHub {
+    name = "tesser";
+    owner = "aphyr";
+    repo = "tesser";
+    rev = "b7b67dfaf25f1764c70c90dc6681dd333d24d6a4";
+    sha256 = "1vma6ram4qs7llnfn84d4xvpn0q7kmzmkmsjpnkpqnryff9w2gvr";
+    cd = "core";
+  };
+  matrix = buildLeinFromGitHub {
     name = "matrix";
-    src = fetchFromGitHub {
-      owner = "mikera";
-      repo = "core.matrix";
-      rev = "f864c29d4e85d35de018295a87a295fc3df632a6";
-      sha256 = "1dywj2av5rwnv7qhh09lpx9c2kx7wvgllwyssvyr75cb6fa6smvg";
+    owner = "mikera";
+    repo = "core.matrix";
+    rev = "f864c29d4e85d35de018295a87a295fc3df632a6";
+    sha256 = "1dywj2av5rwnv7qhh09lpx9c2kx7wvgllwyssvyr75cb6fa6smvg";
+    cd = ".";
     };
-    buildInputs = [ leiningen ];
-    buildPhase = ''
-      # https://blog.jeaye.com/2017/07/30/nixos-revisited/
-      # For leiningen
-      export HOME=$PWD
-      export LEIN_HOME=$HOME/.lein
-      mkdir -p $LEIN_HOME
-      echo "{:user {:local-repo \"$LEIN_HOME\"}}" > $LEIN_HOME/profiles.clj
-      ${leiningen}/bin/lein uberjar
-    '';
-    installPhase = ''
-      cp target/core.matrix-*-SNAPSHOT-standalone.jar $out
-    '';
+  sampling = buildLeinFromGitHub {
+    name = "sampling";
+    owner = "bigmlcom";
+    repo = "sampling";
+    rev = "ef426437ec6c7ba81347110b305f721ca0c7f5e5";
+    sha256 = "1dywj2av5rwnv7qhh09lpx9c2kx7wvgllwyssvyr75cb6fa6smvg";
+    cd = ".";
   };
 in
   stdenv.mkDerivation {
@@ -52,7 +55,7 @@ in
     buildInputs = [ clojure jdk ];
     shellHook = ''
       it () {
-        ${jdk}/bin/java -cp ${tesser}:${matrix}:${clojure}/share/java/clojure.jar clojure.main ${./diaconis.clj}
+        ${jdk}/bin/java -cp ${tesser}:${matrix}:${sampling}:${clojure}/share/java/clojure.jar clojure.main ${./diaconis.clj}
       }
     '';
   }

--- a/diaconis/clojure/default.nix
+++ b/diaconis/clojure/default.nix
@@ -12,9 +12,7 @@ let
       buildInputs = [ leiningen ];
       buildPhase = ''
         # https://blog.jeaye.com/2017/07/30/nixos-revisited/
-        # For leiningen
-        export HOME=$PWD
-        export LEIN_HOME=$HOME/.lein
+        export LEIN_HOME=$PWD/.lein
         mkdir -p $LEIN_HOME
         echo "{:user {:local-repo \"$LEIN_HOME\"}}" > $LEIN_HOME/profiles.clj
         cd ${cd}
@@ -40,14 +38,6 @@ let
     sha256 = "1dywj2av5rwnv7qhh09lpx9c2kx7wvgllwyssvyr75cb6fa6smvg";
     cd = ".";
     };
-  sampling = buildLeinFromGitHub {
-    name = "sampling";
-    owner = "bigmlcom";
-    repo = "sampling";
-    rev = "ef426437ec6c7ba81347110b305f721ca0c7f5e5";
-    sha256 = "1dywj2av5rwnv7qhh09lpx9c2kx7wvgllwyssvyr75cb6fa6smvg";
-    cd = ".";
-  };
 in
   stdenv.mkDerivation {
     name = "diaconis.clj";
@@ -55,7 +45,7 @@ in
     buildInputs = [ clojure jdk ];
     shellHook = ''
       it () {
-        ${jdk}/bin/java -cp ${tesser}:${matrix}:${sampling}:${clojure}/share/java/clojure.jar clojure.main ${./diaconis.clj}
+        ${jdk}/bin/java -cp ${tesser}:${matrix}:${clojure}/share/java/clojure.jar clojure.main ${./diaconis.clj}
       }
     '';
   }

--- a/diaconis/clojure/diaconis.clj
+++ b/diaconis/clojure/diaconis.clj
@@ -5,15 +5,15 @@
   [k 5
    n 500
    zero (m/zero-matrix k k)
-   vecs (for [_ (range n)] (shuffle (range k)))
-   a (->> vecs
+   ps (for [_ (range n)] (shuffle (range k)))
+   a (->> ps
           (map m/permutation-matrix)
           (reduce m/add zero))
    b (->> (t/map m/permutation-matrix)
           (t/reduce m/add zero)
-          (t/tesser [vecs]))
+          (t/tesser [ps]))
    matrices-equal (if (= a b) "Yes" "No")]
   (println (str "Are a and b equal? " matrices-equal "\n"))
-  (m/pm a))
+  (m/pm a {:formatter (comp str int)} ))
 
 (System/exit 0)

--- a/diaconis/clojure/diaconis.clj
+++ b/diaconis/clojure/diaconis.clj
@@ -1,9 +1,10 @@
 (require '[tesser.core :as t])
 (require '[clojure.core.matrix :as m])
+(require '[bigmlcom.sampling.stream :as s])
 
 (let
-  [k 10
-   n 10000
+  [k 5
+   n 500
    zero (m/zero-matrix k k)
    vecs (for [_ (range n)] (shuffle (range k)))
    a (->> vecs
@@ -15,5 +16,7 @@
    matrices-equal (if (= a b) "Yes" "No")]
   (println (str "Are a and b equal? " matrices-equal "\n"))
   (m/pm a))
+
+
 
 (System/exit 0)

--- a/diaconis/clojure/diaconis.clj
+++ b/diaconis/clojure/diaconis.clj
@@ -1,6 +1,5 @@
 (require '[tesser.core :as t])
 (require '[clojure.core.matrix :as m])
-(require '[bigmlcom.sampling.stream :as s])
 
 (let
   [k 5
@@ -16,7 +15,5 @@
    matrices-equal (if (= a b) "Yes" "No")]
   (println (str "Are a and b equal? " matrices-equal "\n"))
   (m/pm a))
-
-
 
 (System/exit 0)

--- a/diaconis/clojure/diaconis.clj
+++ b/diaconis/clojure/diaconis.clj
@@ -14,6 +14,6 @@
           (t/tesser [ps]))
    matrices-equal (if (= a b) "Yes" "No")]
   (println (str "Are a and b equal? " matrices-equal "\n"))
-  (m/pm a {:formatter (comp str int)} ))
+  (m/pm a {:formatter (comp str int)}))
 
 (System/exit 0)

--- a/diaconis/python/diaconis.py
+++ b/diaconis/python/diaconis.py
@@ -21,8 +21,11 @@ def fourier_transform_2(ps):
 
 
 if __name__ == '__main__':
-    N = 10
-    S_N = np.array(list(permutations(range(N))))
-    ps = S_N[np.random.randint(factorial(N), size=10000)]
+    np.random.seed(1729)
+    k = 5
+    n = 500
+    ps = np.repeat([np.arange(k)], n, axis=0)
+    for p in ps:
+        np.random.shuffle(p)
     fhat = fourier_transform(ps)
     print("Permutations:\n{0}\n\nFourier Transform:\n{1}".format(ps, fhat))


### PR DESCRIPTION
Major change:

- added `buildLeinFromGitHub` nix function to cut down _drastically_ on repetition in `default.nix`

Minor changes:

- `np.random.seed(1729)` for repeatability
  - I investigated getting a seeded random for Clojure, but it's too much work/not worth it
- cut down `k` & `n` to 5 & 500, respectively
- took out cleverness in Python generation of permutations; just repeat `np.arange(k)` and shuffle each
- match names (`ps`, not `vecs`)
- integer output formatting in Clojure example